### PR TITLE
Tooling-støtte for OpenAPI 3.1.x er litt mangelvare

### DIFF
--- a/src/main/resources/openapi/documentation.yaml
+++ b/src/main/resources/openapi/documentation.yaml
@@ -1,4 +1,4 @@
-openapi: "3.1.0"
+openapi: "3.0.3"
 info:
   title: "paw_arbeidssoekerregisteret_api_oppslag API"
   description: "paw_arbeidssoekerregisteret_api_oppslag API"


### PR DESCRIPTION
Flere verktøy for OpenAPI er muggen på 3.1.x. Det hadde vært flott om dere kan ligge på 3.0.3 til det blir litt bedre.