### PR TITLE
Fjern enkeltfnutter i eksempelt på Instant

### DIFF
--- a/src/main/resources/openapi/documentation.yaml
+++ b/src/main/resources/openapi/documentation.yaml
@@ -209,7 +209,7 @@ components:
     Instant:
       type: "string"
       format: "date-time"
-      example: "'2021-09-29T11:22:33.444Z'"
+      example: "2021-09-29T11:22:33.444Z"
     BrukerResponse:
       type: "object"
       properties:


### PR DESCRIPTION
De fnuttene skal ikke være der, og brekker dato-parsing